### PR TITLE
Fix dataset featurizer import and training bugs

### DIFF
--- a/dataset_featurizer.py
+++ b/dataset_featurizer.py
@@ -6,6 +6,7 @@ import os
 from tqdm import tqdm
 import deepchem as dc
 from rdkit import Chem
+import numpy as np
 
 print(f"Torch version: {torch.__version__}")
 print(f"Cuda available: {torch.cuda.is_available()}")

--- a/inference.py
+++ b/inference.py
@@ -2,13 +2,15 @@ import torch
 import pandas as pd
 from dataset_featurizer import MoleculeDataset
 from sklearn.metrics import confusion_matrix, accuracy_score, roc_auc_score
+from torch_geometric.data import DataLoader
+
 
 # Load the test dataset
 test_dataset = MoleculeDataset(root="data/split_data", filename="HIV_test.csv", test=True)
 test_loader = DataLoader(test_dataset, batch_size=NUM_GRAPHS_PER_BATCH, shuffle=True)
 
 # Load the trained model
-model = torch.load(os.join.path(output_folder,"model.pth"))
+model = torch.load(os.path.join(output_folder, "model.pth"))
 model.eval()
 
 # Create lists to store the predicted and true labels

--- a/train.py
+++ b/train.py
@@ -101,7 +101,7 @@ print(model)
 # Loss and Optimizer
 # Due to imbalance postive and negative label so apply weight in the +ve side < 1 increases precision, > 1 recall
 weight = torch.tensor([1,10], dtype=torch.float32).to(device)
-loss_fn = torch.nn.CrossEntropyLoss(weight==weight)
+loss_fn = torch.nn.CrossEntropyLoss(weight=weight)
 optimizer = torch.optim.SGD(model.parameters(), 
                             lr=0.1,
                             momentum=0.9)
@@ -246,7 +246,7 @@ print([best_loss])
 
 output_folder = "model_weight"
 os.makedirs(output_folder, exist_ok=True)
-model_path = os.join.path(output_folder,"model.pth") # Replace with the desired path to save the model
+model_path = os.path.join(output_folder, "model.pth")  # Replace with the desired path to save the model
 torch.save(model, model_path)
 
 # %%


### PR DESCRIPTION
## Summary
- fix missing numpy import in dataset_featurizer
- correct CrossEntropyLoss usage
- use `os.path.join` when saving and loading model
- add DataLoader import in inference script

## Testing
- `python -m py_compile dataset_featurizer.py train.py inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6877f5a2344c83209f5330b91e84707a